### PR TITLE
feat: support mentions in text messages

### DIFF
--- a/API.md
+++ b/API.md
@@ -528,6 +528,12 @@ Example replying to some message:
 curl -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"Phone":"5491155554444","Body":"Ditto","ContextInfo":{"StanzaId":"AA3DSE28UDJES3","Participant":"5491155553935@s.whatsapp.net"}}' http://localhost:8080/chat/send/text
 ```
 
+Example sending mentions:
+
+```
+curl -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"Phone":"5491155554444","Body":"Hello @friend","Mentions":["5491155553935"]}' http://localhost:8080/chat/send/text
+```
+
 Response:
 
 ```json

--- a/wuzapi_postman.json
+++ b/wuzapi_postman.json
@@ -438,7 +438,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"Phone\": \"5491155553935\",\n  \"Body\": \"Hello, how are you?\"\n}"
+              "raw": "{\n  \"Phone\": \"5491155553935\",\n  \"Body\": \"Hello, how are you?\",\n  \"Mentions\": [\"5491155553935\"]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/chat/send/text",


### PR DESCRIPTION
## Summary
- allow text message route to accept `mentions` and map them to WhatsApp JIDs
- document mention usage in API docs and Postman collection
- fix log timestamp formatting for edited messages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6897d09129048323a2e713f376480873