### PR TITLE
Decrypt poll events for webhook consumers

### DIFF
--- a/wmiau.go
+++ b/wmiau.go
@@ -470,6 +470,39 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 
 		log.Info().Str("id", evt.Info.ID).Str("source", evt.Info.SourceString()).Str("parts", strings.Join(metaParts, ", ")).Msg("Message Received")
 
+		// Handle poll creation messages
+		if poll := evt.Message.GetPollCreationMessage(); poll != nil {
+			var options []map[string]string
+			for _, opt := range poll.GetOptions() {
+				option := map[string]string{
+					"name": opt.GetOptionName(),
+					"hash": opt.GetOptionHash(),
+				}
+				options = append(options, option)
+			}
+			postmap["poll"] = map[string]interface{}{
+				"name":                   poll.GetName(),
+				"selectableOptionsCount": poll.GetSelectableOptionsCount(),
+				"options":                options,
+			}
+		}
+
+		// Handle poll update (vote) messages
+		if evt.Message.GetPollUpdateMessage() != nil {
+			pollVote, err := mycli.WAClient.DecryptPollVote(context.Background(), evt)
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to decrypt poll vote")
+			} else {
+				var selected []string
+				for _, hash := range pollVote.GetSelectedOptions() {
+					selected = append(selected, fmt.Sprintf("%x", hash))
+				}
+				postmap["pollUpdate"] = map[string]interface{}{
+					"selectedOptions": selected,
+				}
+			}
+		}
+
 		if !*skipMedia {
 			// try to get Image if any
 			img := evt.Message.GetImageMessage()


### PR DESCRIPTION
## Summary
- include poll creation details in message events
- decrypt poll votes to expose selected option hashes

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689babe7a36483238a51d22810e0df50