### PR TITLE
Decrypt poll events for webhook consumers

### DIFF
--- a/API.md
+++ b/API.md
@@ -1504,7 +1504,71 @@ Content-Type: application/json
   "event": {...},
   "type": "ReadReceipt",
   ...
-  "token": "YOUR_TOKEN"
+"token": "YOUR_TOKEN"
+}
+```
+
+## Send Poll
+
+Creates a poll in a group and returns the option hashes so you can map votes later.
+
+Endpoint: _/chat/send/poll_
+
+Method: **POST**
+
+Example:
+
+```
+curl -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"group":"120363025945853632@g.us","header":"Poll test","options":["Yes","No"]}' http://localhost:8080/chat/send/poll
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "Details": "Poll sent successfully",
+    "Id": "3EB00BC40E1A6A3401EB",
+    "Timestamp": "2025-08-12T19:05:41-03:00",
+    "Poll": {
+      "name": "Poll test",
+      "selectableOptionsCount": 1,
+      "options": [
+        {"name": "Yes", "hash": "58e0413224af6b6d3505dd1819d02491c34588de7a4dc6a9ad48a8f7e08e2f7b"},
+        {"name": "No", "hash": "b1f3b9cce13a7f562c74f1c8d1bdbe63e7e85e9d90f11dc996a3654c1b91db68"}
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+## Decrypt Poll Vote
+
+Decrypts an encrypted poll update and returns the hashes of the selected options.
+
+Endpoint: _/api/chat/decrypt/poll_
+
+Method: **POST**
+
+Example:
+
+```
+curl -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"Chat":"120363348518386540@g.us","Sender":"559295333643@s.whatsapp.net","ID":"3EB09D1E6BEC31650FF1DA","IsFromMe":false,"IsGroup":true,"PollCreationMessageKey":{"ID":"3EB00BC40E1A6A3401EB","FromMe":true,"RemoteJID":"120363348518386540@g.us","Participant":"559295333643@s.whatsapp.net"},"Vote":{"EncIV":"cnn0lSIiHk1XCGSy","EncPayload":"y1mt9XB2TgBVZYqvAmC6YX+hzjoHiA3JBwugApppbXCT3ekPnItGaEgcI+TI4Pg4yv0="}}' http://localhost:8080/api/chat/decrypt/poll
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "selectedOptions": [
+      "58e0413224af6b6d3505dd1819d02491c34588de7a4dc6a9ad48a8f7e08e2f7b"
+    ]
+  },
+  "success": true
 }
 ```
 

--- a/routes.go
+++ b/routes.go
@@ -103,8 +103,10 @@ func (s *server) routes() {
 	s.router.Handle("/chat/react", c.Then(s.React())).Methods("POST")
 	s.router.Handle("/chat/send/buttons", c.Then(s.SendButtons())).Methods("POST")
 	s.router.Handle("/chat/send/list", c.Then(s.SendList())).Methods("POST")
-	s.router.Handle("/chat/send/poll", c.Then(s.SendPoll())).Methods("POST")
-	s.router.Handle("/chat/send/edit", c.Then(s.SendEditMessage())).Methods("POST")
+        s.router.Handle("/chat/send/poll", c.Then(s.SendPoll())).Methods("POST")
+        s.router.Handle("/chat/decrypt/poll", c.Then(s.DecryptPoll())).Methods("POST")
+        s.router.Handle("/api/chat/decrypt/poll", c.Then(s.DecryptPoll())).Methods("POST")
+        s.router.Handle("/chat/send/edit", c.Then(s.SendEditMessage())).Methods("POST")
 
 	s.router.Handle("/user/presence", c.Then(s.SendPresence())).Methods("POST")
 	s.router.Handle("/user/info", c.Then(s.GetUser())).Methods("POST")

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -662,7 +662,7 @@ paths:
           content:
             application/json:
               schema:
-                example: {"code":200,"data":{"Details":"Sent","Id":"90B2F8B13FAC8A9CF6B06E99C7834DC5","Timestamp":"2022-04-20T12:49:08-03:00"},"success":true}
+                example: {"code":200,"data":{"Details":"Poll sent successfully","Id":"3EB00BC40E1A6A3401EB","Timestamp":"2025-08-12T19:05:41-03:00","Poll":{"name":"Poll test","selectableOptionsCount":1,"options":[{"name":"Yes","hash":"58e0413224af6b6d3505dd1819d02491c34588de7a4dc6a9ad48a8f7e08e2f7b"},{"name":"No","hash":"b1f3b9cce13a7f562c74f1c8d1bdbe63e7e85e9d90f11dc996a3654c1b91db68"}]}},"success":true}
   /chat/send/edit:
     post:
       tags:
@@ -969,6 +969,27 @@ paths:
             application/json:
               schema:
                 example: {"code":200,"data":{"Details":"Sent","Id":"90B2F8B13FAC8A9CF6B06E99C7834DC5","Timestamp":"2022-04-20T12:49:08-03:00"},"success":true}
+  /api/chat/decrypt/poll:
+    post:
+      tags:
+        - Chat
+      summary: Decrypts a poll vote
+      description: Reveals selected option hashes from an encrypted poll vote.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/PollDecrypt'
+      responses:
+        200:
+          description: Response
+          content:
+            application/json:
+              schema:
+                example: {"code":200,"data":{"selectedOptions":["58e0413224af6b6d3505dd1819d02491c34588de7a4dc6a9ad48a8f7e08e2f7b"]},"success":true}
   /chat/downloadimage:
     post:
       tags:
@@ -1693,10 +1714,59 @@ definitions:
         description: An array of options for the poll.
         items:
           type: string
-          example: "Red"
+        example: "Red"
       Id:
         type: string
         example: "3EB06F9067F80BAB89FF"
+
+  PollDecrypt:
+    type: object
+    required:
+      - Chat
+      - Sender
+      - ID
+      - PollCreationMessageKey
+      - Vote
+    properties:
+      Chat:
+        type: string
+        example: "120363348518386540@g.us"
+      Sender:
+        type: string
+        example: "559295333643@s.whatsapp.net"
+      ID:
+        type: string
+        example: "3EB09D1E6BEC31650FF1DA"
+      IsFromMe:
+        type: boolean
+        example: false
+      IsGroup:
+        type: boolean
+        example: true
+      PollCreationMessageKey:
+        type: object
+        properties:
+          ID:
+            type: string
+            example: "3EB00BC40E1A6A3401EB"
+          FromMe:
+            type: boolean
+            example: true
+          RemoteJID:
+            type: string
+            example: "120363348518386540@g.us"
+          Participant:
+            type: string
+            example: "559295333643@s.whatsapp.net"
+      Vote:
+        type: object
+        properties:
+          EncIV:
+            type: string
+            example: "cnn0lSIiHk1XCGSy"
+          EncPayload:
+            type: string
+            example: "y1mt9XB2TgBVZYqvAmC6YX+hzjoHiA3JBwugApppbXCT3ekPnItGaEgcI+TI4Pg4yv0="
 
   MessageList:
     type: object

--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -386,6 +386,7 @@
                     <tr><td>POST</td><td>/chat/send/buttons</td><td>Envia botões interativos.</td></tr>
                     <tr><td>POST</td><td>/chat/send/list</td><td>Envia lista interativa.</td></tr>
                     <tr><td>POST</td><td>/chat/send/poll</td><td>Envia enquete.</td></tr>
+                    <tr><td>POST</td><td>/api/chat/decrypt/poll</td><td>Descriptografa voto de enquete.</td></tr>
                     <tr><td>POST</td><td>/chat/send/edit</td><td>Edita mensagem enviada.</td></tr>
                     <tr><td>POST</td><td>/chat/presence</td><td>Atualiza estado de digitação do chat.</td></tr>
                     <tr><td>POST</td><td>/chat/markread</td><td>Marca mensagens como lidas.</td></tr>
@@ -1548,6 +1549,63 @@
   "Group": "120363025945853632@g.us",
   "Header": "Votar",
   "Options": ["Sim", "Não"]
+}</code></pre>
+                <h4>Exemplo de Resposta:</h4>
+                <pre><code class="language-json">{
+  "code": 200,
+  "data": {
+    "Details": "Poll sent successfully",
+    "Id": "3EB00BC40E1A6A3401EB",
+    "Timestamp": "2025-08-12T19:05:41-03:00",
+    "Poll": {
+      "name": "Votar",
+      "selectableOptionsCount": 1,
+      "options": [
+        {"name": "Sim", "hash": "58e0413224af6b6d3505dd1819d02491c34588de7a4dc6a9ad48a8f7e08e2f7b"},
+        {"name": "Não", "hash": "b1f3b9cce13a7f562c74f1c8d1bdbe63e7e85e9d90f11dc996a3654c1b91db68"}
+      ]
+    }
+  },
+  "success": true
+}</code></pre>
+            </div>
+            <div class="endpoint">
+                <h3><span class="method post">POST</span> <span class="path">/api/chat/decrypt/poll</span></h3>
+                <p>Descriptografa um voto de enquete retornando os hashes das opções selecionadas.</p>
+
+                <h4>Parâmetros do Corpo:</h4>
+                <table class="api-table">
+                    <thead>
+                        <tr>
+                            <th>Parâmetro</th><th>Tipo</th><th>Descrição</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td class="required">Chat</td><td>string</td><td>JID do chat da enquete.</td></tr>
+                        <tr><td class="required">Sender</td><td>string</td><td>JID de quem enviou o voto.</td></tr>
+                        <tr><td class="required">ID</td><td>string</td><td>ID da mensagem de voto.</td></tr>
+                        <tr><td class="required">PollCreationMessageKey</td><td>object</td><td>Chave da mensagem de criação.</td></tr>
+                        <tr><td class="required">Vote</td><td>object</td><td>Dados criptografados do voto.</td></tr>
+                    </tbody>
+                </table>
+
+                <h4>Exemplo de Requisição:</h4>
+                <pre><code class="language-json">{
+  "Chat": "120363348518386540@g.us",
+  "Sender": "559295333643@s.whatsapp.net",
+  "ID": "3EB09D1E6BEC31650FF1DA",
+  "IsFromMe": false,
+  "IsGroup": true,
+  "PollCreationMessageKey": {
+    "ID": "3EB00BC40E1A6A3401EB",
+    "FromMe": true,
+    "RemoteJID": "120363348518386540@g.us",
+    "Participant": "559295333643@s.whatsapp.net"
+  },
+  "Vote": {
+    "EncIV": "cnn0lSIiHk1XCGSy",
+    "EncPayload": "y1mt9XB2TgBVZYqvAmC6YX+hzjoHiA3JBwugApppbXCT3ekPnItGaEgcI+TI4Pg4yv0="
+  }
 }</code></pre>
             </div>
             <div class="endpoint">


### PR DESCRIPTION
## Summary
- include poll creation details in message events
- decrypt poll votes to expose selected option hashes
- replace encrypted poll vote payload in webhook event with decoded data
- add `/chat/decrypt/poll` endpoint and document usage in Swagger and docs
- expose poll decrypt endpoint under `/api` for easier testing
- strip encrypted vote fields from RawMessage payload
- return poll option hashes on creation for downstream vote mapping

## Testing
- `go vet ./...` *(hangs, terminated)*
- `go test ./...`
- `go build ./...`
- `curl --location 'https://multzap.botadmin.shop/chat/send/poll' --header 'Content-Type: application/json' --header 'token: AiymQDUPy5mhp6rLjHIh' --data-raw '{"group": "120363418433262135@g.us", "header": "Poll test from CI", "options": ["Option A", "Option B"]}'`


------
https://chatgpt.com/codex/tasks/task_e_689babe7a36483238a51d22810e0df50